### PR TITLE
[FIX] Imagens quebradas no menu de baixo

### DIFF
--- a/pourochi.kv
+++ b/pourochi.kv
@@ -447,7 +447,7 @@
                 id: fridge_button
                 size_hint: None, 0.8
                 width: fridge.width
-                source: 'source/images/fridge.jpg'
+                source: 'source/images/fridge.png'
             Texts:
                 size_hint_y: 0.2
                 text: 'Geladeira'
@@ -510,7 +510,7 @@
                 id: shop_button
                 size_hint: None, 0.8
                 width: shop.width
-                source: 'source/images/shop.jpg'
+                source: 'source/images/shop.png'
             Texts:
                 size_hint_y: 0.2
                 text: 'Shop'


### PR DESCRIPTION
Esse PR resolve a issue #1.

Foi feito uma alteração no arquivo `pourochi.kv` onde as extensões das imagens quebradas são alteradas de `.jpg` para `.png`, resolvendo o problema e conseguindo visualizar normalmente os ícones.

![image](https://github.com/athoskenew/pouorochinho/assets/82724852/64102ebf-d213-4faa-86c1-a0475e5a9201)

